### PR TITLE
Refactored deployRoot and zipBytes to be accessed via reflection

### DIFF
--- a/src/main/java/com/salesforce/ant/DeployTaskAdapter.java
+++ b/src/main/java/com/salesforce/ant/DeployTaskAdapter.java
@@ -36,18 +36,6 @@ public class DeployTaskAdapter extends DeployTask {
         super.setZipBytes();
     }
 
-    public void setZipBytes(byte[] value) {
-        zipBytes = value;
-    }
-
-    public byte[] getZipBytes() {
-        return zipBytes;
-    }
-
-    public String getDeployRoot() {
-        return deployRoot;
-    }
-
     public void handleResponse(MetadataConnection metadataConnection, AsyncResult response) {
     }
 }

--- a/src/main/kotlin/com/aquivalabs/force/ant/ReflectionExtensions.kt
+++ b/src/main/kotlin/com/aquivalabs/force/ant/ReflectionExtensions.kt
@@ -1,0 +1,26 @@
+package com.aquivalabs.force.ant
+
+import java.lang.reflect.AccessibleObject
+
+
+internal inline fun <T : AccessibleObject, R> T.asAccessible(body: (T) -> R): R {
+    val oldValue = isAccessible
+    isAccessible = true
+    try {
+        return body(this)
+    } finally {
+        isAccessible = oldValue
+    }
+}
+
+@Suppress("UNCHECKED_CAST")
+internal fun <T> Class<*>.invokeDeclaredMethod(instance: Any?, methodName: String, vararg args: Any?): T =
+    getDeclaredMethod(methodName).asAccessible { return it(instance, args) as T }
+
+@Suppress("UNCHECKED_CAST")
+internal fun <T> Class<*>.getDeclaredFieldValue(instance: Any?, fieldName: String): T =
+    getDeclaredField(fieldName).asAccessible { return it[instance] as T }
+
+@Suppress("UNCHECKED_CAST")
+internal fun <T> Class<*>.setDeclaredFieldValue(instance: Any?, fieldName: String, value: T) =
+    getDeclaredField(fieldName).asAccessible { it[instance] = value }

--- a/src/main/kotlin/com/aquivalabs/force/ant/ReflectionExtensions.kt
+++ b/src/main/kotlin/com/aquivalabs/force/ant/ReflectionExtensions.kt
@@ -14,10 +14,6 @@ internal inline fun <T : AccessibleObject, R> T.asAccessible(body: (T) -> R): R 
 }
 
 @Suppress("UNCHECKED_CAST")
-internal fun <T> Class<*>.invokeDeclaredMethod(instance: Any?, methodName: String, vararg args: Any?): T =
-    getDeclaredMethod(methodName).asAccessible { return it(instance, args) as T }
-
-@Suppress("UNCHECKED_CAST")
 internal fun <T> Class<*>.getDeclaredFieldValue(instance: Any?, fieldName: String): T =
     getDeclaredField(fieldName).asAccessible { return it[instance] as T }
 

--- a/src/test/kotlin/com/aquivalabs/force/ant/DeployWithTestReportsTaskTestCase.kt
+++ b/src/test/kotlin/com/aquivalabs/force/ant/DeployWithTestReportsTaskTestCase.kt
@@ -95,8 +95,8 @@ class DeployWithTestReportsTaskTestCase {
     @Test fun deployRoot_always_shouldReturnValueFromCorrespondingBaseClassPrivateField() {
         val sut = createSystemUnderTest()
         val expected = "foobar"
-        sut.deployRoot = expected
-        assertEquals(sut.deployRoot, expected)
+        sut.setDeployRoot(expected)
+        assertEquals(sut.getDeployRoot(), expected)
     }
 
     @Test(dataProvider = "improperTestLevelForCoverageTestClassData")
@@ -115,7 +115,7 @@ class DeployWithTestReportsTaskTestCase {
 
             // Assert
             val expected = ZipUtil.zipRoot(it)
-            assertEquals(sut.zipBytes, expected)
+            assertEquals(sut.zipBytesField, expected)
         }
     }
 
@@ -149,7 +149,7 @@ class DeployWithTestReportsTaskTestCase {
             // Assert
             val expected = ZipUtil.zipRoot(it)
             assertEquals(
-                sut.zipBytes,
+                sut.zipBytesField,
                 expected,
                 "Should not generate coverage test class if deployRoot didn't contain $fileToRemove")
         }
@@ -177,10 +177,10 @@ class DeployWithTestReportsTaskTestCase {
             sut.addCoverageTestClassToDeployRootPackage(it)
 
             // Assert
-            val actualPackageXml = sut.zipBytes.getEntryContent("package.xml")
-            val actualCoverageTestClass = sut.zipBytes.getEntryContent(
+            val actualPackageXml = sut.zipBytesField.getEntryContent("package.xml")
+            val actualCoverageTestClass = sut.zipBytesField.getEntryContent(
                 "classes/${sut.coverageTestClassName}$APEX_CLASS_FILE_EXTENSION")
-            val actualCoverageTestClassMetadata = sut.zipBytes.getEntryContent(
+            val actualCoverageTestClassMetadata = sut.zipBytesField.getEntryContent(
                 "classes/${sut.coverageTestClassName}$APEX_CLASS_FILE_EXTENSION$META_FILE_EXTENSION")
 
             val expectedClassMembers = linkedSetOf(sut.coverageTestClassName)
@@ -218,10 +218,10 @@ class DeployWithTestReportsTaskTestCase {
             sut.addCoverageTestClassToDeployRootPackage(it)
 
             // Assert
-            val actualPackageXml = sut.zipBytes.getEntryContent("package.xml")
-            val actualCoverageTestClass = sut.zipBytes.getEntryContent(
+            val actualPackageXml = sut.zipBytesField.getEntryContent("package.xml")
+            val actualCoverageTestClass = sut.zipBytesField.getEntryContent(
                 "classes/${sut.coverageTestClassName}$APEX_CLASS_FILE_EXTENSION")
-            val actualCoverageTestClassMetadata = sut.zipBytes.getEntryContent(
+            val actualCoverageTestClassMetadata = sut.zipBytesField.getEntryContent(
                 "classes/${sut.coverageTestClassName}$APEX_CLASS_FILE_EXTENSION$META_FILE_EXTENSION")
 
             assertThat(actualPackageXml, isSimilarTo(packageXml).ignoreWhitespace())
@@ -248,7 +248,7 @@ class DeployWithTestReportsTaskTestCase {
 
             // Assert
             val expected = ZipUtil.readZip(it)
-            assertEquals(sut.zipBytes, expected)
+            assertEquals(sut.zipBytesField, expected)
         }
     }
 
@@ -268,7 +268,7 @@ class DeployWithTestReportsTaskTestCase {
 
             // Assert
             val expected = ZipUtil.readZip(it)
-            assertEquals(sut.zipBytes, expected)
+            assertEquals(sut.zipBytesField, expected)
         }
     }
 
@@ -294,10 +294,10 @@ class DeployWithTestReportsTaskTestCase {
             sut.addCoverageTestClassToZipFilePackage(it)
 
             // Assert
-            val actualPackageXml = sut.zipBytes.getEntryContent("package.xml")
-            val actualCoverageTestClass = sut.zipBytes.getEntryContent(
+            val actualPackageXml = sut.zipBytesField.getEntryContent("package.xml")
+            val actualCoverageTestClass = sut.zipBytesField.getEntryContent(
                 "classes/${sut.coverageTestClassName}$APEX_CLASS_FILE_EXTENSION")
-            val actualCoverageTestClassMetadata = sut.zipBytes.getEntryContent(
+            val actualCoverageTestClassMetadata = sut.zipBytesField.getEntryContent(
                 "classes/${sut.coverageTestClassName}$APEX_CLASS_FILE_EXTENSION$META_FILE_EXTENSION")
 
             val expectedClassMembers = linkedSetOf(sut.coverageTestClassName)
@@ -326,10 +326,10 @@ class DeployWithTestReportsTaskTestCase {
             sut.addCoverageTestClassToZipFilePackage(it)
 
             // Assert
-            val actualPackageXml = sut.zipBytes.getEntryContent("package.xml")
-            val actualCoverageTestClass = sut.zipBytes.getEntryContent(
+            val actualPackageXml = sut.zipBytesField.getEntryContent("package.xml")
+            val actualCoverageTestClass = sut.zipBytesField.getEntryContent(
                 "classes/${sut.coverageTestClassName}$APEX_CLASS_FILE_EXTENSION")
-            val actualCoverageTestClassMetadata = sut.zipBytes.getEntryContent(
+            val actualCoverageTestClassMetadata = sut.zipBytesField.getEntryContent(
                 "classes/${sut.coverageTestClassName}$APEX_CLASS_FILE_EXTENSION$META_FILE_EXTENSION")
 
             assertThat(actualPackageXml, isSimilarTo(packageXml).ignoreWhitespace())
@@ -512,7 +512,7 @@ class DeployWithTestReportsTaskTestCase {
         val sut = DeployWithTestReportsTask()
         sut.project = project
         sut.testLevel = testLevel
-        sut.deployRoot = deployRoot
+        sut.setDeployRoot(deployRoot)
         sut.zipFile = zipFile
         sut.enforceCoverageForAllClasses = enforceCoverageForAllClasses
         return sut

--- a/src/test/kotlin/com/salesforce/ant/DeployTaskAdapterTestCase.kt
+++ b/src/test/kotlin/com/salesforce/ant/DeployTaskAdapterTestCase.kt
@@ -4,7 +4,6 @@ import com.aquivalabs.force.ant.metadataConnection
 import com.aquivalabs.force.ant.randomString
 import com.nhaarman.mockito_kotlin.*
 import com.sforce.soap.metadata.AsyncResult
-import org.testng.Assert.assertEquals
 import org.testng.Assert.assertTrue
 import org.testng.annotations.Test
 import java.lang.reflect.Modifier.isPublic
@@ -21,37 +20,16 @@ class DeployTaskAdapterTestCase {
             "${actual.name} method should be public because it needs to be available from Kotlin code")
     }
 
-    @Test fun setZipBytes_withByteArray_shouldSetBackingFieldValue() {
-        val sut = DeployTaskAdapter()
-        val expected = randomString().toByteArray()
-
-        sut.setZipBytes(expected)
-
-        assertEquals(sut.zipBytes, expected)
-    }
-
-    @Test fun getZipBytes_always_shouldReturnValueFromBackingField() {
-        val sut = DeployTaskAdapter()
-        sut.zipBytes = randomString().toByteArray()
-        assertEquals(sut.getZipBytes(), sut.zipBytes)
-    }
-
-    @Test fun getDeployRoot_always_shouldReturnValueFromBackingField() {
-        val sut = DeployTaskAdapter()
-        sut.deployRoot = randomString()
-        assertEquals(sut.getDeployRoot(), sut.deployRoot)
-    }
-
     @Test fun handleResponse_always_shouldCorrectlyTransformStatusResultToAsyncResult() {
         val sut = spy<DeployTaskAdapter>()
         val inputConnection = metadataConnection()
-        val inputResult = statusResult(id = randomString(),  isDone = true)
+        val inputResult = statusResult(id = randomString(), isDone = true)
 
         sut.handleResponse(inputConnection, inputResult)
 
         verify(sut).handleResponse(
             same(inputConnection),
-            argThat<AsyncResult>{ id == inputResult.id && isDone == inputResult.isDone })
+            argThat<AsyncResult> { id == inputResult.id && isDone == inputResult.isDone })
     }
 
     private fun statusResult(id: String = "", isDone: Boolean = true): SFDCMDAPIAntTask.StatusResult {


### PR DESCRIPTION
The motivation is to prevent `java.lang.IllegalAccessError: tried to access field com.salesforce.ant.DeployTask.* from class com.salesforce.ant.DeployTaskAdapter`.

Possible reason of exception is that both `DeployTask` and `DeployTaskAdapter` sit in same  package but in different .jars -> in different runtime packages. The exception occurs when ant-salesforce.jar and antforce.jar loaded by different classloaders.

Resolves #4.