### PR TITLE
Exclude classes from coverage

### DIFF
--- a/sample/build.xml
+++ b/sample/build.xml
@@ -35,7 +35,7 @@
             <batchtest>
                 <fileset dir="src/classes" includes="*TestClass.cls" />
             </batchtest>
-            <!--<coverageFilter excludes="Book*,*gram, ContactTrigger" />-->
+            <!--<coverageFilter excludes="Book*,*gram, ContactTrigger" excludeNamespaces="aaa, bbb" />-->
             <junitReport dir="junit" suiteName="ApexTests" suiteStrategy="single" />
             <!--<junitReport dir="junit" suiteStrategy="onePerTestClass" />-->
             <coberturaReport file="Apex-Coverage.xml" />

--- a/sample/build.xml
+++ b/sample/build.xml
@@ -35,6 +35,7 @@
             <batchtest>
                 <fileset dir="src/classes" includes="*TestClass.cls" />
             </batchtest>
+            <!--<coverageFilter excludes="Book*,*gram, ContactTrigger" />-->
             <junitReport dir="junit" suiteName="ApexTests" suiteStrategy="single" />
             <!--<junitReport dir="junit" suiteStrategy="onePerTestClass" />-->
             <coberturaReport file="Apex-Coverage.xml" />

--- a/src/main/kotlin/com/aquivalabs/force/ant/DeployWithTestReportsTask.kt
+++ b/src/main/kotlin/com/aquivalabs/force/ant/DeployWithTestReportsTask.kt
@@ -11,11 +11,12 @@ import java.io.File
 data class JUnitReport(var dir: String = "", var suiteName: String = "Apex", var suiteStrategy: String = "single")
 data class CoberturaReport(var file: String = "Apex-Coverage.xml")
 data class HtmlCoverageReport(var dir: String = "", var codeHighlighting: Boolean = false)
+data class CoverageFilter(var excludes: String = "")
 
 open class DeployWithTestReportsTask : DeployTaskAdapter() {
     internal val fileReporters = hashMapOf<String, Reporter<File>>()
-    internal val consoleReporters = hashMapOf<String, Reporter<Unit>>(
-        "TeamCity" to TeamCityReporter())
+    internal val consoleReporters = hashMapOf<String, Reporter<Unit>>("TeamCity" to TeamCityReporter())
+    internal var excludeFromCoverageRegex = Regex("")
 
     fun getDeployRoot(): String? = DeployTask::class.java.getDeclaredFieldValue(this, "deployRoot")
     var zipBytesField: ByteArray
@@ -75,6 +76,12 @@ open class DeployWithTestReportsTask : DeployTaskAdapter() {
                 codeHighlighting = report.codeHighlighting)
     }
 
+    fun addConfiguredCoverageFilter(filter: CoverageFilter) {
+        excludeFromCoverageRegex = Regex(
+            filter.excludes.replace(" ", "").replace("*", "\\w*").replace(",", "|"),
+            RegexOption.IGNORE_CASE)
+    }
+
     fun createBatchTest(): BatchTest {
         val batch = BatchTest(getProject())
         batchTests.add(batch)
@@ -82,8 +89,10 @@ open class DeployWithTestReportsTask : DeployTaskAdapter() {
     }
 
     override fun getRunTests(): Array<out String>? = when (testLevel) {
-        TestLevel.RunSpecifiedTests.name -> super.getRunTests()
-            .union(batchTests.flatMap { it.getFileNames() })
+        TestLevel.RunSpecifiedTests.name -> batchTests
+            .flatMap { it.getFileNames() }
+            .map { it.substringAfterLast('/')}
+            .union(super.getRunTests().asIterable())
             .toTypedArray()
         else -> emptyArray()
     }
@@ -104,6 +113,7 @@ open class DeployWithTestReportsTask : DeployTaskAdapter() {
         if (testLevel != null && testLevel != TestLevel.NoTestRun.name) {
             val deployResult = metadataConnection.checkDeployStatus(response.id, true)
             removeCoverageTestClassFrom(deployResult.details.runTestResult)
+            applyCoverageFilter(deployResult.details.runTestResult)
 
             consoleReporters.values.forEach { it.createReport(deployResult) }
 
@@ -129,5 +139,14 @@ open class DeployWithTestReportsTask : DeployTaskAdapter() {
                 .toTypedArray()
             testResult.numTestsRun -= 1
         }
+    }
+
+    internal fun applyCoverageFilter(testResult: RunTestsResult) {
+        testResult.codeCoverage = testResult.codeCoverage
+            .filterNot { it.name.matches(excludeFromCoverageRegex) }
+            .toTypedArray()
+        testResult.codeCoverageWarnings = testResult.codeCoverageWarnings
+            .filterNot { it.name.matches(excludeFromCoverageRegex) }
+            .toTypedArray()
     }
 }


### PR DESCRIPTION
Added coverage filter to `deploy` task. It can exclude classes or triggers from coverage reports by:

- names: 
```xml
<coverageFilter excludes="MyClass" />
```
- name wildcards
```xml
<coverageFilter excludes="My*" />
```
- comma-separated list of class names (white spaces are optional)
```xml
<coverageFilter excludes="MyClass, MyOtherClass,YetAnotherClass" />
```
- namespaces
```xml
<coverageFilter excludeNamespaces="fooba" />
```
- comma-separated list of class namespaces (white spaces are optional)
```xml
<coverageFilter excludeNamespaces="fooba,baz, barbaz" />
```
- any combination of above methods
```xml
<coverageFilter excludes="MyClass, *Other*,Yet*" excludeNamespaces="fooba,baz, barbaz" />
```

`deploy` task supports only one `coverageFilter` element.