### PR TITLE
Added support of ZipFileSets in BatchTest element.

### DIFF
--- a/sample/build.xml
+++ b/sample/build.xml
@@ -56,7 +56,7 @@
             reportDir="${outputdir}/test-reports"
             enforceCoverageForAllClasses="true">
             <batchtest>
-                <fileset dir="src/classes" includes="*TestClass.cls" />
+                <zipfileset src="src.zip" includes="classes/*TestClass.cls" />
             </batchtest>
             <junitReport dir="junit" suiteName="ApexTests" suiteStrategy="single" />
             <coberturaReport file="Apex-Coverage.xml" />

--- a/src/main/kotlin/com/aquivalabs/force/ant/BatchTest.kt
+++ b/src/main/kotlin/com/aquivalabs/force/ant/BatchTest.kt
@@ -3,7 +3,9 @@ package com.aquivalabs.force.ant
 import org.apache.tools.ant.Project
 import org.apache.tools.ant.types.FileSet
 import org.apache.tools.ant.types.Resource
+import org.apache.tools.ant.types.ZipFileSet
 import org.apache.tools.ant.types.resources.Resources
+import java.io.File
 
 class BatchTest(val project: Project) {
     val resources = Resources()
@@ -16,10 +18,15 @@ class BatchTest(val project: Project) {
         resources.add(fileSet)
     }
 
-    fun getFileNames(): List<String> = resources
+    fun addZipFileSet(zipFileSet: ZipFileSet) = addFileSet(zipFileSet)
+
+    fun getFileNames(): Set<String> = resources
         .filter { it.isExists && it.name.endsWith(APEX_CLASS_FILE_EXTENSION) }
         .map { prefix + getTestClassNameFrom(it) }
+        .toSet()
 
-    private fun getTestClassNameFrom(resource: Resource) =
-        resource.name.substring(0, resource.name.length - APEX_CLASS_FILE_EXTENSION.length)
+    private fun getTestClassNameFrom(resource: Resource) = resource.name
+        .split(File.pathSeparator).last()
+        .split(File.separator).last()
+        .dropLast(APEX_CLASS_FILE_EXTENSION.length)
 }

--- a/src/test/kotlin/com/aquivalabs/force/ant/BatchTestTestCase.kt
+++ b/src/test/kotlin/com/aquivalabs/force/ant/BatchTestTestCase.kt
@@ -1,8 +1,9 @@
 package com.aquivalabs.force.ant
 
 import org.apache.tools.ant.Project
-import org.hamcrest.MatcherAssert
-import org.hamcrest.Matchers
+import org.apache.tools.ant.types.ZipFileSet
+import org.hamcrest.MatcherAssert.*
+import org.hamcrest.Matchers.*
 import org.testng.Assert.assertEquals
 import org.testng.Assert.assertTrue
 import org.testng.annotations.DataProvider
@@ -10,15 +11,24 @@ import org.testng.annotations.Test
 
 
 class BatchTestTestCase {
-    @Test fun addFileSet_always_shouldFollowAntNamingConventions() {
-        MatcherAssert.assertThat(
-            "Prefix 'add' is one of the Ant's conventions for nested elements declaration. " +
-                "See the manual: http://ant.apache.org/manual/develop.html#nested-elements",
+    @Test
+    fun addFileSet_always_shouldFollowAntNamingConventions() {
+        assertThat(
+            nestedElementConvention("add"),
             BatchTest::addFileSet.name,
-            Matchers.startsWith("add"))
+            startsWith("add"))
     }
 
-    @Test fun addFileSet_always_shouldFillProjectPropertyOfPassedValue() = withTestDirectory {
+    @Test
+    fun addZipFileSet_always_shouldFollowAntNamingConventions() {
+        assertThat(
+            nestedElementConvention("add"),
+            BatchTest::addZipFileSet.name,
+            startsWith("add"))
+    }
+
+    @Test
+    fun addFileSet_always_shouldFillProjectPropertyOfPassedValue() = withTestDirectory {
         val sut = createSystemUnderTest()
         val input = fileSet(it)
 
@@ -27,9 +37,10 @@ class BatchTestTestCase {
         assertEquals(input.project, sut.project)
     }
 
-    @Test fun addFileSet_always_shouldAddFileSetToResources() = withTestDirectory {
+    @Test
+    fun addFileSet_always_shouldAddFileSetToResources() = withTestDirectory {
         val sut = createSystemUnderTest()
-        val input = fileSet(it , "foo", "bar")
+        val input = fileSet(it, "foo", "bar")
 
         sut.addFileSet(input)
 
@@ -38,11 +49,35 @@ class BatchTestTestCase {
         }
     }
 
-    @Test(dataProvider = "getFileNamesTestData")
-    fun getFileNames_always_shouldReturnCorrectResult(
+    @Test
+    fun addZipFileSet_always_shouldFillProjectPropertyOfPassedValue() = withZipFile { zipFile ->
+        val sut = createSystemUnderTest()
+        val input = ZipFileSet().apply { src = zipFile }
+
+        sut.addZipFileSet(input)
+
+        assertEquals(input.project, sut.project)
+    }
+
+    @Test
+    fun addZipFileSet_always_shouldAddFileSetToResources() {
+        withZipFile(classes = setOf("foo", "bar")) { zipFile ->
+            val sut = createSystemUnderTest()
+            val input = ZipFileSet().apply { src = zipFile }
+
+            sut.addZipFileSet(input)
+
+            input.forEach {
+                assertTrue(sut.resources.contains(it))
+            }
+        }
+    }
+
+    @Test(dataProvider = "getFileNamesFileSetTestData")
+    fun getFileNames_withFileSet_shouldReturnCorrectResult(
         namespace: String,
-        inputFileNames: List<String>,
-        expected: List<String>,
+        inputFileNames: Set<String>,
+        expected: Set<String>,
         message: String) = withTestDirectory {
 
         val sut = createSystemUnderTest()
@@ -54,29 +89,75 @@ class BatchTestTestCase {
     }
 
     @DataProvider
-    fun getFileNamesTestData(): Array<Array<Any>> = arrayOf(
-        arrayOf(
-            "",
-            listOf<String>(),
-            listOf<String>(),
-            "Should return empty list for empty fileSet"
-        ),
-        arrayOf(
-            "",
-            listOf("foo.pdf", "bar.trigger", "baz$APEX_CLASS_FILE_EXTENSION"),
-            listOf("baz"),
-            "Should return only names (without extensions) of files that have $APEX_CLASS_FILE_EXTENSION extension"
-        ),
-        arrayOf(
-            "namespace",
-            listOf("foo$APEX_CLASS_FILE_EXTENSION"),
-            listOf("namespace${NAMESPACE_SEPARATOR}foo"),
-            "Should add namespace to file names"
-        ))
-
-    fun createSystemUnderTest(): BatchTest {
-        val project = Project()
-        project.name = "TestProject"
-        return BatchTest(project)
+    fun getFileNamesFileSetTestData(): Array<Array<Any>> {
+        return arrayOf(
+            arrayOf(
+                "",
+                setOf<String>(),
+                setOf<String>(),
+                "Should return empty list for empty fileSet"),
+            arrayOf(
+                "",
+                setOf("foo.pdf", "bar.trigger", "baz$APEX_CLASS_FILE_EXTENSION"),
+                setOf("baz"),
+                "Should return only names (without extensions) of files that have $APEX_CLASS_FILE_EXTENSION extension"),
+            arrayOf(
+                "namespace",
+                setOf("foo$APEX_CLASS_FILE_EXTENSION"),
+                setOf("namespace${NAMESPACE_SEPARATOR}foo"),
+                "Should add namespace to file names"))
     }
+
+    @Test(dataProvider = "getFileNamesZipFileSetTestData")
+    fun getFileNames_withZipFileSet_shouldReturnCorrectResult(
+        namespace: String,
+        classNames: Set<String>,
+        triggerNames: Set<String>,
+        expected: Set<String>,
+        message: String) = withZipFile(classes = classNames, triggers = triggerNames) { zipFile ->
+
+        val sut = createSystemUnderTest()
+        sut.namespace = namespace
+        val input = ZipFileSet().apply { src = zipFile }
+        sut.addZipFileSet(input)
+
+        assertEquals(sut.getFileNames(), expected, message)
+    }
+
+    @DataProvider
+    fun getFileNamesZipFileSetTestData(): Array<Array<Any>> {
+        return arrayOf(
+            arrayOf(
+                "",
+                setOf<String>(),
+                setOf<String>(),
+                setOf<String>(),
+                "Should return empty list for empty zipFileSet"),
+            arrayOf(
+                "",
+                setOf<String>(),
+                setOf("foo"),
+                setOf<String>(),
+                "Should ignore triggers from zipFileSet"),
+            arrayOf(
+                "",
+                setOf("foo"),
+                setOf("foo"),
+                setOf("foo"),
+                "Should ignore triggers from zipFileSet (same class and trigger name)"),
+            arrayOf(
+                "",
+                setOf("foo", "bar", "baz"),
+                setOf<String>(),
+                setOf("foo", "bar", "baz"),
+                "Should return only names (without extensions) of files that have $APEX_CLASS_FILE_EXTENSION extension"),
+            arrayOf(
+                "namespace",
+                setOf("foo"),
+                setOf<String>(),
+                setOf("namespace${NAMESPACE_SEPARATOR}foo"),
+                "Should add namespace to file names"))
+    }
+
+    fun createSystemUnderTest(): BatchTest = BatchTest(Project().apply { name = "TestProject" })
 }


### PR DESCRIPTION
To being able to use wildcards to define test class names that should be run during deployment support of `ZipFileSets` was added to `BatchTest`.

For example:
```xml
<target name="deployZip">
    <antforce:deploy
            username="${sf.username}"
            password="${sf.password}${sf.token}"
            serverUrl="${sf.server}"
            zipFile="src.zip"
            testLevel="RunSpecifiedTests">
        <batchtest>
            <zipfileset src="src.zip" includes="classes/*TestClass.cls" />
        </batchtest>
    </antforce:deploy>
</target>
```

Fixes #6 